### PR TITLE
Add GitHub actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,31 @@
+name: continuous integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test (default)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install CMake
+        uses: lukka/get-cmake@latest
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: clippy
+          cache: true
+      - run: cargo test --features static
+      - if: matrix.rust == 'stable'
+        run: cargo clippy
+        env:
+          RUSTFLAGS: -W warnings


### PR DESCRIPTION
After GitHub actions is enabled, this will ensure that the crate builds and that the (future) tests pass.